### PR TITLE
Update AGP

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,7 +23,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.2.1" apply false
+    id "com.android.application" version "8.3.0" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     // END: FlutterFire Configuration


### PR DESCRIPTION
## Summary
- bump AGP version to 8.3.0

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843af28cd14832bac321176bef5f6e9