### PR TITLE
Update Info.plist with ATS settings

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -59,5 +59,12 @@
     	</dict>
     </array>
     <!-- End of the Google Sign-in Section -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <false/>
+        <!-- If the app requires HTTP access to specific domains, list them under
+             NSExceptionDomains. -->
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add `NSAppTransportSecurity` section to disable arbitrary HTTP loads

## Testing
- `plutil -lint -- ios/Runner/Info.plist`
- `flutter build ios --no-codesign` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438534b534832bbb86813592bc8ccf