### PR TITLE
Replace debug prints with logger

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,4 +7,4 @@ linter:
     use_key_in_widget_constructors: false
     prefer_const_literals_to_create_immutables: false
     prefer_const_constructors_in_immutables: false
-    avoid_print: false
+    avoid_print: true

--- a/lib/app_initializer.dart
+++ b/lib/app_initializer.dart
@@ -9,6 +9,7 @@ import 'package:fono_terapia/database/app_database.dart';
 import 'package:fono_terapia/database/dao/category_dao.dart';
 import 'package:fono_terapia/database/firebase_database.dart';
 import 'package:fono_terapia/shared/utils/responsive_size.dart';
+import 'package:fono_terapia/shared/utils/logger.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
 
@@ -33,60 +34,60 @@ class AppInitializer {
     await userDataStorage.clearUserData();
     activePurchases = [];
     purchasesRestored = false;
-    print("Logged out, cleared purchase state.");
+    logDebug("Logged out, cleared purchase state.");
   }
 
   static Future<void> initializeApp(BuildContext context) async {
     try {
-      print("[AppInitializer] Starting app initialization...");
+      logDebug("[AppInitializer] Starting app initialization...");
 
       // Initialize Firebase
-      print("[AppInitializer] Initializing Firebase...");
+      logDebug("[AppInitializer] Initializing Firebase...");
       await Firebase.initializeApp(
           // options: DefaultFirebaseOptions.currentPlatform,
           );
-      print("[AppInitializer] Firebase initialized successfully.");
+      logDebug("[AppInitializer] Firebase initialized successfully.");
 
       // Initialize database
-      print("[AppInitializer] Initializing local database...");
+      logDebug("[AppInitializer] Initializing local database...");
       database = await openOrInitializeDatabase();
-      print("[AppInitializer] Local database initialized successfully.");
+      logDebug("[AppInitializer] Local database initialized successfully.");
 
       // Initialize responsiveSize
-      print("[AppInitializer] Initializing responsiveSize...");
+      logDebug("[AppInitializer] Initializing responsiveSize...");
       responsiveSize = ResponsiveSize(mediaQueryData: MediaQuery.of(context));
-      print("[AppInitializer] responsiveSize initialized successfully.");
+      logDebug("[AppInitializer] responsiveSize initialized successfully.");
 
       // Initialize Auth and UserService
-      print(
+      logDebug(
           "[AppInitializer] Initializing authentication and user services...");
       authRepository = AuthRepository();
       userDataStorage = UserDataStorage();
       userService = UserService(userDataStorage);
-      print("[AppInitializer] Auth and UserService initialized successfully.");
+      logDebug("[AppInitializer] Auth and UserService initialized successfully.");
 
       // Initialize FirebaseDatabase
-      print("[AppInitializer] Initializing Firebase Database...");
+      logDebug("[AppInitializer] Initializing Firebase Database...");
       firebaseDatabase = FirebaseDatabase();
-      print("[AppInitializer] Firebase Database initialized successfully.");
+      logDebug("[AppInitializer] Firebase Database initialized successfully.");
 
       // Initialize DAOs
-      print("[AppInitializer] Initializing DAOs...");
+      logDebug("[AppInitializer] Initializing DAOs...");
       categoryDao = CategoryDao();
       gameResultRepository = GameResultRepository(
           firebaseDatabase: firebaseDatabase, db: database);
-      print("[AppInitializer] DAOs initialized successfully.");
+      logDebug("[AppInitializer] DAOs initialized successfully.");
 
-      print("[AppInitializer] App initialization completed successfully.");
+      logDebug("[AppInitializer] App initialization completed successfully.");
     } catch (e) {
-      print("[AppInitializer] Error during app initialization: $e");
+      logDebug("[AppInitializer] Error during app initialization: $e");
       rethrow;
     }
   }
 
   // New function that initializes the in-app purchase services and validation logic
   static Future<void> initializePurchaseServices() async {
-    print("INITIALIZING PURCHASE SERVICES");
+    logDebug("INITIALIZING PURCHASE SERVICES");
     // Initialize InAppPurchase instance and listener
     inAppPurchase = InAppPurchase.instance;
 
@@ -101,31 +102,31 @@ class AppInitializer {
   }
 
   static void _initializePurchaseListener() {
-    print('Initializing global purchase listener');
+    logDebug('Initializing global purchase listener');
     final Stream<List<PurchaseDetails>> purchaseUpdated =
         inAppPurchase.purchaseStream;
 
-    print('Attaching global listener to purchaseStream...');
+    logDebug('Attaching global listener to purchaseStream...');
     purchaseUpdated.listen((List<PurchaseDetails> purchaseDetailsList) {
-      print(
+      logDebug(
           'Global purchase update received, length: ${purchaseDetailsList.length}');
       activePurchases =
           purchaseDetailsList; // Store the received purchases globally
     }, onError: (error) {
-      print("Error in global purchase stream: $error");
+      logDebug("Error in global purchase stream: $error");
     });
   }
 
   static Future<void> _restorePurchases() async {
-    print("Restoring previous purchases...");
+    logDebug("Restoring previous purchases...");
     purchasesRestored = false; // Reset flag
 
     try {
       await inAppPurchase.restorePurchases();
-      print("Purchases restored successfully");
+      logDebug("Purchases restored successfully");
       purchasesRestored = true; // Mark as restored
     } catch (e) {
-      print("Error restoring purchases: $e");
+      logDebug("Error restoring purchases: $e");
       purchasesRestored =
           true; // Mark as done, even on failure to avoid blocking
     }
@@ -133,11 +134,11 @@ class AppInitializer {
 
   // Add a function to validate the subscription
   static Future<void> _validateSubscription() async {
-    print("Validating subscription status at startup...");
+    logDebug("Validating subscription status at startup...");
 
     // Wait until `activePurchases` is populated
     if (activePurchases.isEmpty) {
-      print("Waiting for global purchase data...");
+      logDebug("Waiting for global purchase data...");
       await Future.delayed(Duration(seconds: 2));
     }
 
@@ -158,16 +159,16 @@ class AppInitializer {
     }
 
     if (!subscriptionIsActive) {
-      print("Subscription is not active.");
+      logDebug("Subscription is not active.");
     } else {
-      print("Subscription is active.");
+      logDebug("Subscription is active.");
     }
   }
 
   // Verify subscription with the store (App Store/Play Store)
   static Future<bool> _verifySubscription(
       PurchaseDetails purchaseDetails) async {
-    print("Verifying subscription for product: ${purchaseDetails.productID}");
+    logDebug("Verifying subscription for product: ${purchaseDetails.productID}");
 
     // Add any additional logic for verifying receipt if needed here
     return purchaseDetails.status == PurchaseStatus.purchased ||
@@ -190,7 +191,7 @@ class AppInitializer {
             .update({
           'isPremium': isPremium,
         });
-        print('Subscription status updated in Firestore: $isPremium');
+        logDebug('Subscription status updated in Firestore: $isPremium');
       }
     }
   }

--- a/lib/data/auth_repository.dart
+++ b/lib/data/auth_repository.dart
@@ -4,6 +4,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'dart:convert';
 import 'dart:math';
+import 'package:fono_terapia/shared/utils/logger.dart';
 
 class AuthRepository {
   final FirebaseAuth _auth = FirebaseAuth.instance;
@@ -31,7 +32,7 @@ class AuthRepository {
         return userCredential.user;
       }
     } catch (e) {
-      print("Google Sign-In Error: $e");
+      logDebug("Google Sign-In Error: $e");
     }
     return null;
   }
@@ -39,12 +40,12 @@ class AuthRepository {
   // Sign in with Apple
   Future<User?> signInWithApple() async {
     try {
-      print("Starting Apple Sign-In process...");
+      logDebug("Starting Apple Sign-In process...");
 
       // Generate nonce and hash
       final rawNonce = generateNonce();
       final nonceHash = sha256ofString(rawNonce);
-      print("Nonce generated and hashed.");
+      logDebug("Nonce generated and hashed.");
 
       // Get Apple credential
       final appleCredential = await SignInWithApple.getAppleIDCredential(
@@ -55,12 +56,12 @@ class AuthRepository {
         nonce: nonceHash,
       );
 
-      print("AppleIDCredential received:");
-      print("  Email: ${appleCredential.email}");
-      print(
+      logDebug("AppleIDCredential received:");
+      logDebug("  Email: ${appleCredential.email}");
+      logDebug(
           "  Full Name: ${appleCredential.givenName} ${appleCredential.familyName}");
-      print("  Identity Token: ${appleCredential.identityToken}");
-      print("  User ID: ${appleCredential.userIdentifier}");
+      logDebug("  Identity Token: ${appleCredential.identityToken}");
+      logDebug("  User ID: ${appleCredential.userIdentifier}");
 
       // Check if the identity token is null
       if (appleCredential.identityToken == null) {
@@ -74,23 +75,23 @@ class AuthRepository {
         rawNonce: rawNonce,
       );
 
-      print("OAuthCredential created, attempting Firebase sign-in...");
+      logDebug("OAuthCredential created, attempting Firebase sign-in...");
 
       // Sign in with the generated credential
       final UserCredential userCredential =
           await _auth.signInWithCredential(oauthCredential);
 
       if (userCredential.user != null) {
-        print("Firebase sign-in successful. User: ${userCredential.user!.uid}");
-        print("User email: ${userCredential.user!.email}");
+        logDebug("Firebase sign-in successful. User: ${userCredential.user!.uid}");
+        logDebug("User email: ${userCredential.user!.email}");
       } else {
-        print("Firebase sign-in returned no user.");
+        logDebug("Firebase sign-in returned no user.");
       }
 
       return userCredential.user;
     } catch (e, stackTrace) {
-      print("Apple Sign-In Error: $e");
-      print("Stack Trace: $stackTrace");
+      logDebug("Apple Sign-In Error: $e");
+      logDebug("Stack Trace: $stackTrace");
       return null;
     }
   }

--- a/lib/data/service/user_service.dart
+++ b/lib/data/service/user_service.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fono_terapia/data/user_data_storage.dart';
 import 'package:fono_terapia/shared/model/user_data.dart';
+import 'package:fono_terapia/shared/utils/logger.dart';
 
 class UserService {
   final UserDataStorage userDataStorage;
@@ -9,20 +10,20 @@ class UserService {
   UserService(this.userDataStorage);
 
   Future<bool> isNewUser(User user) async {
-    print('Checking if user is new...');
+    logDebug('Checking if user is new...');
     DocumentSnapshot userDoc = await FirebaseFirestore.instance
         .collection('Users')
         .doc(user.uid)
         .get();
 
     bool isNew = !userDoc.exists;
-    print('User is ${isNew ? "new" : "existing"}');
+    logDebug('User is ${isNew ? "new" : "existing"}');
     return isNew;
   }
 
 // Function to check subscription when user is already logged in
   Future<String> checkSubscriptionValidity(User user) async {
-    print('Checking subscription validity for user: ${user.uid}');
+    logDebug('Checking subscription validity for user: ${user.uid}');
 
     // Retrieve Firestore subscription status
     DocumentSnapshot userDoc = await FirebaseFirestore.instance
@@ -30,14 +31,14 @@ class UserService {
         .doc(user.uid)
         .get();
 
-    print('Loaded user document from Firestore');
+    logDebug('Loaded user document from Firestore');
 
     // Load local user data from SharedPreferences
     UserData? localUserData = await userDataStorage.loadUserData();
 
     if (localUserData == null) {
       // If no local data exists, fetch from Firestore
-      print('No UserData found in SharedPreferences, fetching from Firestore...');
+      logDebug('No UserData found in SharedPreferences, fetching from Firestore...');
       if (userDoc.exists) {
         localUserData = UserData(
           name: userDoc['name'],
@@ -46,29 +47,29 @@ class UserService {
         // Save fetched user data locally
         await userDataStorage.saveUserData(localUserData);
       } else {
-        print('User data not found in Firestore.');
+        logDebug('User data not found in Firestore.');
       }
     }
 
     bool isPremiumLocal = localUserData?.isPremium ?? false;
-    print('Local premium status: $isPremiumLocal');
+    logDebug('Local premium status: $isPremiumLocal');
 
     // Get Firestore subscription status
     bool isPremiumFirestore = userDoc['isPremium'] ?? false;
-    print('Firestore premium status: $isPremiumFirestore');
+    logDebug('Firestore premium status: $isPremiumFirestore');
 
     // Check if subscription has been validated
     bool isSubscriptionValid = isPremiumFirestore || isPremiumLocal;
 
     // If subscription status differs between sources, update accordingly
     if (isSubscriptionValid != isPremiumLocal) {
-      print('Updating local subscription status...');
+      logDebug('Updating local subscription status...');
       await userDataStorage.updatePremiumStatus(isSubscriptionValid);
     }
 
     // Navigate based on the subscription status
     String route = isSubscriptionValid ? "/menu" : "/goPremium";
-    print('Navigating to: $route');
+    logDebug('Navigating to: $route');
     return route;
   }
 }

--- a/lib/data/user_data_storage.dart
+++ b/lib/data/user_data_storage.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:fono_terapia/shared/model/user_data.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:fono_terapia/shared/utils/logger.dart';
 
 class UserDataStorage {
   static const String _userDataKey = 'user_data';
@@ -10,7 +11,7 @@ class UserDataStorage {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     String jsonString = jsonEncode(userData.toJson());
     await prefs.setString(_userDataKey, jsonString);
-    print('UserData saved: $jsonString'); // Debugging log
+    logDebug('UserData saved: $jsonString');
   }
 
   // Load UserData from SharedPreferences
@@ -19,12 +20,12 @@ class UserDataStorage {
     String? jsonString = prefs.getString(_userDataKey);
 
     if (jsonString == null) {
-      print('No UserData found in SharedPreferences'); // Debugging log
+      logDebug('No UserData found in SharedPreferences');
       return null;
     }
 
     Map<String, dynamic> jsonMap = jsonDecode(jsonString);
-    print('UserData loaded: $jsonString'); // Debugging log
+    logDebug('UserData loaded: $jsonString');
     return UserData.fromJson(jsonMap);
   }
 
@@ -39,9 +40,9 @@ class UserDataStorage {
       userData.isPremium = isPremium;
 
       await saveUserData(userData);  // Reuse saveUserData to update the SharedPreferences
-      print('Premium status updated: $isPremium'); // Debugging log
+      logDebug('Premium status updated: $isPremium');
     } else {
-      print('No UserData found to update premium status'); // Debugging log
+      logDebug('No UserData found to update premium status');
     }
   }
 
@@ -49,6 +50,6 @@ class UserDataStorage {
   Future<void> clearUserData() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.remove(_userDataKey);
-    print('UserData cleared from SharedPreferences'); // Debugging log
+    logDebug('UserData cleared from SharedPreferences');
   }
 }

--- a/lib/modules/goPremium/go_premium_viewmodel.dart
+++ b/lib/modules/goPremium/go_premium_viewmodel.dart
@@ -3,6 +3,7 @@ import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:fono_terapia/data/auth_repository.dart';
 import 'package:fono_terapia/data/user_data_storage.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fono_terapia/shared/utils/logger.dart';
 
 class GoPremiumViewModel extends ChangeNotifier {
   final AuthRepository authRepository;
@@ -24,22 +25,22 @@ class GoPremiumViewModel extends ChangeNotifier {
   // Fetch available subscriptions from the store
   Future<void> _fetchAvailableSubscriptions() async {
     const Set<String> _kIds = <String>{'subscription_monthly'};
-    print("Fetching available subscriptions...");
+    logDebug("Fetching available subscriptions...");
     final ProductDetailsResponse response = await iap.queryProductDetails(_kIds);
 
-    print("ProductDetailsResponse: ${response.productDetails}");
-    print("NotFoundIDs: ${response.notFoundIDs}");
+    logDebug("ProductDetailsResponse: ${response.productDetails}");
+    logDebug("NotFoundIDs: ${response.notFoundIDs}");
 
     if (response.notFoundIDs.isNotEmpty) {
-      print("Subscription product not found: ${response.notFoundIDs}");
+      logDebug("Subscription product not found: ${response.notFoundIDs}");
     }
 
     availableProducts = response.productDetails;
 
     if (availableProducts.isEmpty) {
-      print("No products found in the store.");
+      logDebug("No products found in the store.");
     } else {
-      print("Available products: ${availableProducts.map((p) => p.id).join(', ')}");
+      logDebug("Available products: ${availableProducts.map((p) => p.id).join(', ')}");
     }
 
     notifyListeners();
@@ -52,7 +53,7 @@ class GoPremiumViewModel extends ChangeNotifier {
       final PurchaseParam purchaseParam = PurchaseParam(productDetails: product);
       iap.buyNonConsumable(purchaseParam: purchaseParam);
     } else {
-      print("No products available for purchase");
+      logDebug("No products available for purchase");
     }
   }
 
@@ -60,15 +61,15 @@ class GoPremiumViewModel extends ChangeNotifier {
   void _initializePurchaseListener() {
     final Stream<List<PurchaseDetails>> purchaseUpdated = iap.purchaseStream;
 
-    print('Attaching local listener to purchaseStream...');
+    logDebug('Attaching local listener to purchaseStream...');
     purchaseUpdated.listen((List<PurchaseDetails> purchaseDetailsList) {
-      print('Purchase update received, length: ${purchaseDetailsList.length}');
+      logDebug('Purchase update received, length: ${purchaseDetailsList.length}');
       for (var purchaseDetails in purchaseDetailsList) {
-        print("Purchase details: ${purchaseDetails.productID}, status: ${purchaseDetails.status}");
+        logDebug("Purchase details: ${purchaseDetails.productID}, status: ${purchaseDetails.status}");
         handlePurchaseUpdate(purchaseDetails);
       }
     }, onError: (error) {
-      print("Error in purchase stream: $error");
+      logDebug("Error in purchase stream: $error");
     });
   }
 
@@ -77,57 +78,57 @@ class GoPremiumViewModel extends ChangeNotifier {
     if (purchaseDetails.pendingCompletePurchase) {
       try {
         await iap.completePurchase(purchaseDetails);
-        print("Purchase completed: ${purchaseDetails.productID}");
+        logDebug("Purchase completed: ${purchaseDetails.productID}");
       } catch (e) {
-        print("Error completing purchase: $e");
+        logDebug("Error completing purchase: $e");
       }
     }
   }
 
   // Handle purchase updates that will come from the global listener
   Future<void> handlePurchaseUpdate(PurchaseDetails purchaseDetails) async {
-    print("Handling purchase update: ${purchaseDetails.productID}, status: ${purchaseDetails.status}");
+    logDebug("Handling purchase update: ${purchaseDetails.productID}, status: ${purchaseDetails.status}");
 
     if (purchaseDetails.status == PurchaseStatus.purchased || purchaseDetails.status == PurchaseStatus.restored) {
-      print("Purchase status valid, verifying subscription...");
+      logDebug("Purchase status valid, verifying subscription...");
       await _verifyAndDeliverSubscription(purchaseDetails);
     } else {
-      print("Unhandled purchase status: ${purchaseDetails.status}");
+      logDebug("Unhandled purchase status: ${purchaseDetails.status}");
     }
 
-    print("Confirming purchase: ${purchaseDetails.productID}");
+    logDebug("Confirming purchase: ${purchaseDetails.productID}");
     await confirmPurchase(purchaseDetails);
   }
 
   // Verify and deliver the subscription to the user
   Future<void> _verifyAndDeliverSubscription(PurchaseDetails purchaseDetails) async {
-    print("Validating subscription for product: ${purchaseDetails.productID}");
+    logDebug("Validating subscription for product: ${purchaseDetails.productID}");
 
     var user = await authRepository.currentUser;
     if (user == null) {
-      print("No authenticated user found.");
+      logDebug("No authenticated user found.");
       return;
     }
 
-    print("Authenticated user: ${user.uid}");
+    logDebug("Authenticated user: ${user.uid}");
 
     var userData = await userDataStorage.loadUserData();
     if (userData == null) {
-      print("No user data found in local storage.");
+      logDebug("No user data found in local storage.");
     } else {
-      print("User data found, marking as premium.");
+      logDebug("User data found, marking as premium.");
       userData.isPremium = true;
       await userDataStorage.saveUserData(userData);
     }
 
     try {
-      print("Updating Firestore for user: ${user.uid}");
+      logDebug("Updating Firestore for user: ${user.uid}");
       await FirebaseFirestore.instance.collection('Users').doc(user.uid).update({
         'isPremium': true,
       });
-      print("Firestore updated successfully.");
+      logDebug("Firestore updated successfully.");
     } catch (e) {
-      print("Error updating Firestore: $e");
+      logDebug("Error updating Firestore: $e");
     }
 
     isPremium = true;

--- a/lib/shared/utils/logger.dart
+++ b/lib/shared/utils/logger.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/foundation.dart';
+
+void logDebug(String message) {
+  if (kDebugMode) {
+    debugPrint(message);
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple debug logger utility
- swap `print` calls for `logDebug` in auth repository
- replace `print` statements in shared storage and services
- ensure premium view model and initializer use logger
- enforce `avoid_print` lint

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843852f247c832bbc55e0d11180bd8c